### PR TITLE
fix potential null references, and address CA1825 zero-length array allocations

### DIFF
--- a/src/Our.Umbraco.SuperValueConverters/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Our.Umbraco.SuperValueConverters/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -19,8 +19,8 @@ namespace Our.Umbraco.SuperValueConverters.ValueConverters
 
             var settings = new PickerSettings
             {
-                AllowedTypes = configuration.Filter.Split(',') ?? new string[] { },
-                MaxItems = configuration.MaxNumber
+                AllowedTypes = configuration?.Filter?.Split(',') ?? System.Array.Empty<string>(),
+                MaxItems = configuration?.MaxNumber ?? 0
             };
 
             return settings;


### PR DESCRIPTION
Null reference on configuration.Filter was causing the following error

![image](https://user-images.githubusercontent.com/629719/71969883-76562500-31ff-11ea-843a-b406991b1f39.png)

Added null checks/safe nav operators for potental null references, and fixed the roslyn warning for CA1825