### PR TITLE
Fix IntersectMany to actually compute the intersection

### DIFF
--- a/src/Our.Umbraco.SuperValueConverters/Extensions/IEnumerableExtensions.cs
+++ b/src/Our.Umbraco.SuperValueConverters/Extensions/IEnumerableExtensions.cs
@@ -17,7 +17,7 @@ namespace Our.Umbraco.SuperValueConverters.Extensions
                 }
                 else
                 {
-                    intersection.Intersect(value);
+                    intersection = intersection.Intersect(value);
                 }
             }
 


### PR DESCRIPTION
In the current implementation, the return value of `Intersect` is not saved. As this is a 'pure method' that returns a new collection instead of modifying the original one, the calculation of the intersection is never saved. As a result, the returned 'intersection' is simply the list of the first value.

By saving the intersection result, this is resolved and from my quick tests, the returned intersection is correct.

This issue exists in both the v7 and v8 versions. This PR is for the v7 version as that is what I was working on when I found this out.