### PR TITLE
Prevent possible NullReferenceException

### DIFF
--- a/src/Our.Umbraco.SuperValueConverters/ValueConverters/SuperValueConverterBase.cs
+++ b/src/Our.Umbraco.SuperValueConverters/ValueConverters/SuperValueConverterBase.cs
@@ -49,7 +49,7 @@ namespace Our.Umbraco.SuperValueConverters.ValueConverters
 
             var modelType = typeof(IPublishedContent);
 
-            if (settings.AllowedDoctypes.Any() == true)
+            if (settings.AllowedDoctypes != null && settings.AllowedDoctypes.Any() == true)
             {
                 if (ModelsBuilderHelper.IsEnabled() == true)
                 {


### PR DESCRIPTION
In some cases, the prevalues of the datatype may not contain the AllowedDoctypes key, resulting in `settings.AllowedDoctypes` to be null. This in turn, caused the entire website to be broken for me due to the NullReferenceException being thrown. Saving the DataType causes the prevalues to be there as expected, but I believe the library should not break the site.

This quickfix solves this issue. Another possibility is making sure that `settings.AllowedDoctypes` is initialized as an empty array by default, but I'll leave that decision up to you.