### PR TITLE
Add return value of Intersect method.

### DIFF
--- a/src/Our.Umbraco.SuperValueConverters/Extensions/IEnumerableExtensions.cs
+++ b/src/Our.Umbraco.SuperValueConverters/Extensions/IEnumerableExtensions.cs
@@ -17,7 +17,7 @@ namespace Our.Umbraco.SuperValueConverters.Extensions
                 }
                 else
                 {
-                    intersection.Intersect(value);
+                    intersection = intersection.Intersect(value);
                 }
             }
 


### PR DESCRIPTION
Add missing assignment of return value method for intersect. 

This causes issue when for 2 different Document Types got Last Interface of first allowed type.

It could be also changed to :

`return intersection.Intersect(value);`