### PR TITLE
Update MNTP PVC to handle Umbraco special properties

### DIFF
--- a/src/Our.Umbraco.SuperValueConverters/ValueConverters/MultiNodeTreePickerValueConverter.cs
+++ b/src/Our.Umbraco.SuperValueConverters/ValueConverters/MultiNodeTreePickerValueConverter.cs
@@ -1,13 +1,25 @@
-﻿using Our.Umbraco.SuperValueConverters.Models;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Our.Umbraco.SuperValueConverters.Models;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
 using Core = Umbraco.Cms.Core.PropertyEditors.ValueConverters;
 
 namespace Our.Umbraco.SuperValueConverters.ValueConverters
 {
     public class MultiNodeTreePickerValueConverter : SuperValueConverterBase
     {
+    
+        private static readonly List<string> PropertiesToExclude = new List<string>
+        {
+            Constants.Conventions.Content.InternalRedirectId.ToLower(CultureInfo.InvariantCulture),
+            Constants.Conventions.Content.Redirect.ToLower(CultureInfo.InvariantCulture)
+        };
+    
         public MultiNodeTreePickerValueConverter(Core.MultiNodeTreePickerValueConverter baseValueConverter, TypeLoader typeLoader)
             : base(baseValueConverter, typeLoader)
         {
@@ -29,6 +41,18 @@ namespace Our.Umbraco.SuperValueConverters.ValueConverters
             }
 
             return settings;
+        }
+        
+        public override object ConvertIntermediateToObject(IPublishedElement owner, IPublishedPropertyType propertyType, PropertyCacheLevel referenceCacheLevel, object inter, bool preview)
+        {
+            if ((propertyType.Alias == null || PropertiesToExclude.InvariantContains(propertyType.Alias)) )
+            {
+                var udis = (Udi[])inter;
+
+                return udis.FirstOrDefault();
+            } 
+
+            return base.ConvertIntermediateToObject(owner, propertyType, referenceCacheLevel, inter, preview);
         }
     }
 }


### PR DESCRIPTION
Take the logic from the Umbraco core MNTP PVC around special properties and add it into the SVC version. This allows the expected behaviour to continue to function addressing #21