### PR TITLE
fix: excluded IPublishedElement from GetTypeForAllowedTypes

### DIFF
--- a/src/Our.Umbraco.SuperValueConverters/ValueConverters/SuperValueConverterBase.cs
+++ b/src/Our.Umbraco.SuperValueConverters/ValueConverters/SuperValueConverterBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -76,7 +76,8 @@ namespace Our.Umbraco.SuperValueConverters.ValueConverters
                 {
                     var interfaces = types.Select(x => x
                         .GetInterfaces()
-                        .Where(i => i.IsPublic));
+                        .Where(i => i.IsPublic)
+                        .Where(i => i != typeof(IPublishedElement)));
 
                     var sharedInterfaces = interfaces.IntersectMany();
 


### PR DESCRIPTION
Excluded IPublishedElement from GetTypeForAllowedTypes to let the default behaviour use IPublishedContent, _see more_ https://github.com/callumbwhyte/super-value-converters/issues/12

 _smartypants_ 😃 

